### PR TITLE
Exercise 1

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import GuidelinesUpload from "@/components/guidelines-upload";
 import MedicalRecordUpload from "@/components/medical-record-upload";
+import CaseSubmitButton from "@/components/case-submit-button";
 import { useRouter } from "next/navigation";
 
 export const revalidate = 0;
@@ -21,12 +22,7 @@ export default async function DashboardRoot() {
 				<GuidelinesUpload />
 			</div>
 			<div className="w-full py-4 flex flex-row justify-center">
-				<button
-					className="bg-green-600 font-medium text-white py-2 px-4 rounded"
-					onClick={handleContinue}
-				>
-					Continue
-				</button>
+				<CaseSubmitButton handleContinue={handleContinue} />
 			</div>
 		</div>
 	)

--- a/frontend/components/case-submit-button/index.tsx
+++ b/frontend/components/case-submit-button/index.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useDashboard } from "@/context/dashboard-context";
+import classNames from "classnames";
+
+export default function CaseSubmitButton({handleContinue}: {handleContinue: () => void}) {
+    const { medicalRecord, guidelinesFile } = useDashboard();
+
+    const disabled = medicalRecord === null || guidelinesFile === null;
+
+    return <button
+            className={classNames("font-medium text-white py-2 px-4 rounded",
+                disabled ? "bg-gray-300" : "bg-green-600"
+            )}
+            onClick={handleContinue}
+            disabled={disabled}
+        >
+        Continue
+    </button>
+}

--- a/frontend/components/guidelines-upload/index.tsx
+++ b/frontend/components/guidelines-upload/index.tsx
@@ -13,8 +13,8 @@ export default function GuidelinesUpload() {
 
     const handleClick = () => {
         setShowSpinner(true);
-        setGuidelinesFile({ url: "/assets/guidelines.pdf" });
         setTimeout(() => {
+            setGuidelinesFile({ url: "/assets/guidelines.pdf" });
             setShowSpinner(false);
         }, SPINNER_TIMEOUT);
     }

--- a/frontend/components/guidelines-upload/index.tsx
+++ b/frontend/components/guidelines-upload/index.tsx
@@ -1,18 +1,27 @@
 "use client";
 
+import { useState } from 'react';
 import { useDashboard} from "@/context/dashboard-context";
 import classNames from "classnames";
-import { FaCheck } from "react-icons/fa";
+import { FaCheck, FaSpinner } from "react-icons/fa";
+
+const SPINNER_TIMEOUT = 3000;
 
 export default function GuidelinesUpload() {
+    const [ showSpinner, setShowSpinner ] = useState(false);
     const { guidelinesFile, setGuidelinesFile } = useDashboard();
 
     const handleClick = () => {
+        setShowSpinner(true);
         setGuidelinesFile({ url: "/assets/guidelines.pdf" });
+        setTimeout(() => {
+            setShowSpinner(false);
+        }, SPINNER_TIMEOUT);
     }
 
     return(
         <div className="w-1/2 h-64 border border-4 border-gray-200 border-dashed rounded flex flex-row items-center justify-center">
+            {showSpinner ? <FaSpinner className="animate-spin text-gray-400" />: 
             <button
                 className={classNames(
                     "text-white font-medium py-2 px-4 rounded border border-2",
@@ -27,7 +36,7 @@ export default function GuidelinesUpload() {
                         <span>Guidelines File Uploaded</span>
                     </span>
                 )}
-            </button>
+            </button>}
         </div>
     )
 }

--- a/frontend/components/guidelines-upload/index.tsx
+++ b/frontend/components/guidelines-upload/index.tsx
@@ -9,7 +9,7 @@ const SPINNER_TIMEOUT = 3000;
 
 export default function GuidelinesUpload() {
     const [ showSpinner, setShowSpinner ] = useState(false);
-    const { guidelinesFile, setGuidelinesFile } = useDashboard();
+    const { medicalRecord, guidelinesFile, setGuidelinesFile } = useDashboard();
 
     const handleClick = () => {
         setShowSpinner(true);
@@ -21,22 +21,27 @@ export default function GuidelinesUpload() {
 
     return(
         <div className="w-1/2 h-64 border border-4 border-gray-200 border-dashed rounded flex flex-row items-center justify-center">
-            {showSpinner ? <FaSpinner className="animate-spin text-gray-400" />: 
-            <button
-                className={classNames(
-                    "text-white font-medium py-2 px-4 rounded border border-2",
-                    guidelinesFile === null ? "bg-orange-500 border-orange-500" : "border-transparent text-green-600" 
+            {medicalRecord === null ? 
+                <div className="text-gray-500 text-center">
+                    <span>Upload Medical Record First</span>
+                </div> :
+                (showSpinner ? <FaSpinner className="animate-spin text-gray-400" /> : 
+                    <button
+                        className={classNames(
+                            "text-white font-medium py-2 px-4 rounded border border-2",
+                            guidelinesFile === null ? "bg-orange-500 border-orange-500" : "border-transparent text-green-600" 
+                        )}
+                        onClick={handleClick}
+                    >
+                        {guidelinesFile === null && (<span>Simulate Guidelines Upload</span>)}
+                        {guidelinesFile !== null && (
+                            <span className="text-green-600 flex flex-row gap-1 items-center">
+                                <FaCheck />
+                                <span>Guidelines File Uploaded</span>
+                            </span>
+                        )}
+                    </button>
                 )}
-                onClick={handleClick}
-            >
-                {guidelinesFile === null && (<span>Simulate Guidelines Upload</span>)}
-                {guidelinesFile !== null && (
-                    <span className="text-green-600 flex flex-row gap-1 items-center">
-                        <FaCheck />
-                        <span>Guidelines File Uploaded</span>
-                    </span>
-                )}
-            </button>}
         </div>
     )
 }

--- a/frontend/components/medical-record-upload/index.tsx
+++ b/frontend/components/medical-record-upload/index.tsx
@@ -1,18 +1,27 @@
 "use client";
 
+import { useState } from 'react';
 import { useDashboard } from "@/context/dashboard-context";
 import classNames from "classnames";
-import { FaCheck } from "react-icons/fa";
+import { FaCheck, FaSpinner } from "react-icons/fa";
+
+const SPINNER_TIMEOUT = 3000;
 
 export default function MedicalRecordUpload() {
+    const [ showSpinner, setShowSpinner ] = useState(false);
     const { medicalRecord, setMedicalRecord } = useDashboard();
 
     const handleClick = () => {
+        setShowSpinner(true);
         setMedicalRecord({ url: "/assets/medical-record.pdf" });
+        setTimeout(() => {
+            setShowSpinner(false);
+        }, SPINNER_TIMEOUT);
     }
 
     return(
         <div className="w-1/2 h-64 border border-4 border-gray-200 border-dashed rounded flex flex-row items-center justify-center">
+            {showSpinner ? <FaSpinner className="animate-spin text-gray-400" />: 
             <button
                 className={classNames(
                     "text-white font-medium py-2 px-4 rounded border border-2",
@@ -27,7 +36,7 @@ export default function MedicalRecordUpload() {
                         <span>Medical Record Uploaded</span>
                     </span>
                 )}
-            </button>
+            </button>}
         </div>
     )
 }

--- a/frontend/components/medical-record-upload/index.tsx
+++ b/frontend/components/medical-record-upload/index.tsx
@@ -13,8 +13,8 @@ export default function MedicalRecordUpload() {
 
     const handleClick = () => {
         setShowSpinner(true);
-        setMedicalRecord({ url: "/assets/medical-record.pdf" });
         setTimeout(() => {
+            setMedicalRecord({ url: "/assets/medical-record.pdf" });
             setShowSpinner(false);
         }, SPINNER_TIMEOUT);
     }


### PR DESCRIPTION
Per exercise 1 in https://anterior.notion.site/Senior-Product-Engineer-Take-Home-6e82ec45cc2a46b59a0d9ee3aeb9449c

1. On the two file upload simulation buttons that appear on `/dashboard`:
    1. Add a spinner that appears for three seconds before displaying the success message
    2. Add a green tick alongside the success message
2. Only display the Continue button on the `/dashboard` screen once a (simulated) medical record and guidelines doc have been uploaded
3. Do not allow the User to upload a Guidelines file until a Medical Record has been uploaded. You can use the `react-toast` library to show the user a prompt.

For 2, instead of only displaying when both uploaded, decided disable and then enable once both uploaded. This way no shifting of UI (or no unnecessary ghost div)